### PR TITLE
feat: clarify API key registering

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -96,3 +96,20 @@ Show specific command help:
                                     [include, -i].
     -p, --page INTEGER              Specify data page  [default: 0]
     -h, --help                      Show this message and exit.
+    
+
+Bootstraping:
+------------
+  
+You may want to registry your API key. 
+
+.. code-block:: bash
+
+    netlas query savekey YOUR_API_KEY
+
+
+netlas as now saved your key, you can now use the CLI as such:
+
+.. code-block:: bash
+
+    netlas query 'THE_QUERY'


### PR DESCRIPTION
Why: 
Registering the API key using the CLI is not clear in the actual documentation. 

How:
Giving and example of API key registering.

Further discussions : 
The code should maybe throw an error if incompatible flag are used, maybe ? 